### PR TITLE
Control logging by NOLOG compile switch

### DIFF
--- a/include/AdaptiveWidthPartitioner.h
+++ b/include/AdaptiveWidthPartitioner.h
@@ -48,8 +48,10 @@ namespace embeddedpenguins::modelengine
 
         virtual unsigned long int Partition(unsigned long long int workCutoffTick) override
         {
-            //context_.Logger.Logger() << "Starting Partition\n";
-            //context_.Logger.Logit();
+#ifndef NOLOG
+            context_.Logger.Logger() << "Starting Partition\n";
+            context_.Logger.Logit();
+#endif
 
             AccumulateWorkFromAllWorkers();
             auto cutoffPoint = FindCutoffPoint(workCutoffTick);
@@ -64,8 +66,6 @@ namespace embeddedpenguins::modelengine
             }
 #endif
 
-            //context_.Logger.Logger() << "Partitioning with " << workForTimeSlice.size() << " work items\n";
-            //context_.Logger.Logit();
             auto totalWork = workForTimeSlice.size();
             context_.TotalWork += totalWork;
             ++context_.Iterations;
@@ -95,9 +95,6 @@ namespace embeddedpenguins::modelengine
                 begin(externalSourceWork), 
                 end(externalSourceWork));
             externalSourceWork.clear();
-
-            //context_.Logger.Logger() << "Partition found a total of " << totalSourceWork_.size() << " work items\n";
-            //context_.Logger.Logit();
         }
 
         typename vector<WorkItem<OPERATORTYPE>>::iterator FindCutoffPoint(unsigned long long int workCutoffTick)
@@ -108,8 +105,6 @@ namespace embeddedpenguins::modelengine
                 [workCutoffTick](const WorkItem<OPERATORTYPE>& work){
                     return work.Tick < workCutoffTick;
             });
-            //context_.Logger.Logger() << "Partition found cutoff point for time " << Log::FormatTime(workCutoffTime) << " at " << cutoffPoint - begin(totalSourceWork_) << "\n";
-            //context_.Logger.Logit();
 
             return cutoffPoint;
         }

--- a/include/ModelEngineThread.h
+++ b/include/ModelEngineThread.h
@@ -119,8 +119,10 @@ namespace embeddedpenguins::modelengine
         void MainLoop()
         {
             auto engineStartTime = high_resolution_clock::now();
+#ifndef NOLOG
             context_.Logger.Logger() << "ModelEngine starting main loop\n";
             context_.Logger.Logit();
+#endif
 
             auto quit {false};
             do
@@ -136,8 +138,10 @@ namespace embeddedpenguins::modelengine
             auto engineElapsed = duration_cast<microseconds>(high_resolution_clock::now() - engineStartTime).count();
             auto partitionElapsed = context_.PartitionTime.count();
 
+#ifndef NOLOG
             context_.Logger.Logger() << "ModelEngine quitting main loop\n";
             context_.Logger.Logit();
+#endif
 
             double partitionRatio = (double)partitionElapsed / (double)engineElapsed;
             cout 
@@ -180,6 +184,7 @@ namespace embeddedpenguins::modelengine
 
         void DoWorkWithAllWorkers()
         {
+#ifndef NOLOG
             if (context_.LoggingLevel == LogLevel::Diagnostic)
             {
                 auto workPresent { false };
@@ -212,11 +217,10 @@ namespace embeddedpenguins::modelengine
             }
             else if (context_.LoggingLevel != LogLevel::None)
             {
-#ifndef NOLOG
                 context_.Logger.Logger() << "Starting work phase\n";
                 context_.Logger.Logit();
-#endif
             }
+#endif
 
             for (auto& worker : context_.Workers)
                 worker->Scan(WorkCode::Scan);
@@ -229,12 +233,16 @@ namespace embeddedpenguins::modelengine
             context_.Workers[0]->Scan(WorkCode::FinalScan);
             context_.Workers[0]->WaitForPreviousScan();
 
+#ifndef NOLOG
             context_.Logger.Logger() << "ModelEngine waiting for worker threads to quit\n";
             context_.Logger.Logit();
+#endif
             for (auto& worker : context_.Workers)
                 worker->Join();
+#ifndef NOLOG
             context_.Logger.Logger() << "ModelEngine joined all worker threads\n";
             context_.Logger.Logit();
+#endif
         }
    };
 }


### PR DESCRIPTION
Added #ifndef NOLOG around all logging in the model engine.  Similar guards are needed for application logging.